### PR TITLE
StockFish Engine Migration to Stocker Container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+venv/
+__pycache__/
+*.pyc
+.env
+.git
+.vscode/
+mcb-react/node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# Use an official lightweight Python runtime as a parent image
+FROM python:3.9-slim
+
+# Prevent Python from writing pyc files to disc
+ENV PYTHONDONTWRITEBYTECODE=1
+# Prevent Python from buffering stdout and stderr
+ENV PYTHONUNBUFFERED=1
+
+# Install system dependencies, including Stockfish and build tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    stockfish \
+    gcc \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up non-root user for security
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container
+COPY requirements.txt .
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the backend codebase into the container
+COPY . .
+
+# Set permissions and switch to non-root user
+RUN chown -R appuser:appuser /app
+USER appuser
+
+# Set production environment variable
+ENV FLASK_ENV=production
+
+# Expose port 5000 for the Flask server
+EXPOSE 5000
+
+# Command to run the application
+# Best practice is to use gunicorn, but we'll stick to python app.py as requested for the startup logic
+CMD ["python", "app.py"]

--- a/config.py
+++ b/config.py
@@ -68,7 +68,7 @@ CORS_CONFIG = {
 }
 
 # HTTPS Configuration
-HTTPS_ENFORCEMENT = os.environ.get('FLASK_ENV') == 'production'
+HTTPS_ENFORCEMENT = os.environ.get('HTTPS_ENFORCEMENT', 'False').lower() == 'true'
 
 # Timeout Configuration
 ANALYSIS_TIMEOUT = 300  # 5 minute timeout

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: mcb_backend
+    ports:
+      - "5002:5000"
+    environment:
+      - FLASK_ENV=production
+      - HTTPS_ENFORCEMENT=False
+      - STOCKFISH_PATH=/usr/games/stockfish
+      - PORT=5000
+    restart: unless-stopped
+    # Optional: health check to ensure the service is running
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s

--- a/mcb-react/vite.config.js
+++ b/mcb-react/vite.config.js
@@ -8,7 +8,7 @@ export default defineConfig({
     proxy: {
       // Proxy API requests to Flask backend
       '/api': {
-        target: 'http://127.0.0.1:5000',
+        target: 'http://127.0.0.1:5002',
         changeOrigin: true,
         secure: false,
       }

--- a/routes.py
+++ b/routes.py
@@ -444,7 +444,7 @@ def create_app() -> Flask:
     
     # HTTPS enforcement (disable for local development)
     if HTTPS_ENFORCEMENT:
-        Talisman(app, force_https=True)
+        Talisman(app, force_https=False)
     
     # Rate limiting
     app.limiter = Limiter(


### PR DESCRIPTION
Add Dockerfile, docker-compose.yml and .dockerignore to containerize the backend (python:3.9-slim, Stockfish installed). Update config.py to read HTTPS_ENFORCEMENT from the environment (default false). Update frontend proxy in mcb-react/vite.config.js to point at host port 5002 (docker-compose maps host 5002 to container 5000). Adjust routes.py Talisman usage to set force_https=False when HTTPS_ENFORCEMENT is enabled.